### PR TITLE
Fix: Initialize new_value variable to prevent unbound variable error

### DIFF
--- a/infrastructure.sh
+++ b/infrastructure.sh
@@ -853,7 +853,7 @@ manage_boolean_variable() {
     local default_value="${3:-false}"
     local prompt_text="${4:-$variable_name}"
 
-    local current_value new_value
+    local current_value new_value=""
 
     # Get current value
     current_value=$(get_github_variable "$variable_name" "$repo_name")
@@ -1803,7 +1803,7 @@ update_management_public_ip() {
 }
 
 update_production_environment_variables() {
-    local current_value new_value
+    local current_value new_value=""
 
     # Get current value from infrastructure repo
     current_value=$(get_github_variable "PRODUCTION_ENVIRONMENT" "$INFRASTRUCTURE_REPO_NAME")


### PR DESCRIPTION
## Problem
The infrastructure script was failing with an unbound variable error when users declined to change boolean variables:
```
./infrastructure.sh: line 879: new_value: unbound variable
```

## Root Cause
The script uses `set -u` which causes failures when accessing unbound variables. In two functions:
- `manage_boolean_variable()`
- `update_production_environment_variables()`

The `new_value` variable was declared as local but not initialized, causing the error when the user chose not to change a boolean variable.

## Solution
- Initialize `new_value` variables with empty string (`""`) in both affected functions
- This ensures compatibility with `set -u` while maintaining existing logic
- No functional changes to the script behavior

## Testing
- Script now runs without errors when users decline to change boolean variables
- All existing functionality remains intact

## Files Changed
- `infrastructure.sh`: Fixed variable initialization in two functions

Resolves the unbound variable error that prevented script execution.