### PR TITLE
Fix unbound variable errors in prompt functions

### DIFF
--- a/infrastructure.sh
+++ b/infrastructure.sh
@@ -386,7 +386,7 @@ log_progress() {
 prompt_confirmation() {
     local prompt="$1"
     local default="${2:-N}"
-    local response
+    local response=""
     local max_attempts=3
     local attempt=1
 
@@ -418,7 +418,7 @@ prompt_secret() {
     local prompt="$1"
     local variable_name="$2"
     local min_length="${3:-$MIN_PASSWORD_LENGTH}"
-    local value
+    local value=""
     local max_attempts=3
     local attempt=1
 
@@ -459,9 +459,9 @@ prompt_secret() {
 prompt_text() {
     local prompt="$1"
     local variable_name="$2"
-    local default="$3"
-    local validation_func="$4"  # Optional validation function
-    local value
+    local default="${3:-}"
+    local validation_func="${4:-}"  # Optional validation function
+    local value=""
     local max_attempts=3
     local attempt=1
 


### PR DESCRIPTION
This PR fixes unbound variable errors that occur when running the infrastructure script with bash strict mode (set -u).

## Changes Made

- **prompt_confirmation()**: Initialize  variable with empty string
- **prompt_secret()**: Initialize  variable with empty string  
- **prompt_text()**: 
  - Use proper parameter expansion  and  for optional parameters
  - Initialize  variable with empty string

## Problem Solved

The script was failing with "unbound variable" errors at line 462 when users declined boolean variable changes during Azure subscription selection. This was caused by:

1. Accessing  parameter without checking if it was provided
2. Uninitialized local variables in functions when using  strict mode

## Testing

- ✅ Script now runs  command without errors
- ✅ Validates proper parameter handling for optional function arguments
- ✅ Maintains backward compatibility with existing function calls

Fixes the infrastructure script execution failure reported by the user.